### PR TITLE
Add missing semicolon

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ macro_rules! push_log_scope {
                 }
             });
         }
-        let __logger_scoped_message = $crate::Scope
+        let __logger_scoped_message = $crate::Scope;
     );
     ($($arg:tt)+) => (push_log_scope!(format_args!($($arg)+)));
 }


### PR DESCRIPTION
This fixes the following warning on nightly:
```
warning: expected `;`, found `<eof>`
 --> <scoped_log macros>:8:71
  |
8 | push ( scope ) ; } } } ) ; } let __logger_scoped_message = $ crate :: Scope )

  |                                                                       ^^^^^
  |
  = note: This was erroneously allowed and will become a hard error in a future release
```